### PR TITLE
Add Universiti Putra Malaysia (upm.edu.my)

### DIFF
--- a/lib/domains/my/edu/upm.txt
+++ b/lib/domains/my/edu/upm.txt
@@ -1,0 +1,1 @@
+Universiti Putra Malaysia


### PR DESCRIPTION
This pull request adds Universiti Putra Malaysia to the list of domains.

Domain: upm.edu.my
Official website: https://www.upm.edu.my/

The file lib/domains/my/edu/upm.txt contains the official name of the institution.